### PR TITLE
Declare correct peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "npm-check-updates": "^2.14.0"
   },
   "peerDependencies": {
-    "emotion": ">=10.0.0"
+    "@emotion/core": ">=10.0.0"
   }
 }


### PR DESCRIPTION
`emotion` is for framework agnostic use, but `index.js` imports from `@emotion/core` which is for use with React.